### PR TITLE
enhance common API by enabling service discovery

### DIFF
--- a/nodejs/channelHelper.js
+++ b/nodejs/channelHelper.js
@@ -1,0 +1,41 @@
+const Client = require('./client');
+const Peer = require('./peer');
+
+/**
+ * connect to a channel given the config of discovery peer and user credentials
+ *
+ * @param channelName
+ * @param discoverPeerUrl: discovery peer URL
+ * @param discoverPeerHost: discovery peer hostname
+ * @param tlsCaPemPath:  file path of TLS CA certificate for the discovery peer
+ * @param userName: name of user that'll be used to connect the given channel
+ * @param userMspId: MSP ID of user that'll be used to connect the given channel
+ * @param keyPath: file path of private key of user that'll be used to connect the given channel
+ * @param certPath: file path of certificate of user that'll be used to connect the given channel
+ * @returns {Promise<{client: *, channel: *}>}
+ */
+exports.connect = async (channelName,
+                        {peerUrl, peerHostname, tlsCaPemPath},
+                        {username, mspId, keyPath, certPath}) =>{
+    const client = await Client.newClientWithUser({username, mspId, keyPath, certPath});
+    const discoveryPeer = Peer.buildPeer(client, peerUrl, peerHostname, tlsCaPemPath)
+    const channel = await connectChannel(client, channelName, discoveryPeer);
+    return {client, channel}
+};
+
+/**
+ * connect channel enabling service discovery feature
+ *
+ * @param client
+ * @param channelName
+ * @param discoveryPeer
+ * @returns {Promise<*>}
+ */
+const connectChannel = async (client, channelName, discoveryPeer ) => {
+    const channel = client.newChannel(channelName);
+    await channel.initialize({
+        discover: true,
+        target: discoveryPeer
+    });
+    return channel;
+}

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -2,8 +2,8 @@
   "name": "nodejs",
   "version": "1.4.0",
   "dependencies": {
-    "fabric-ca-client": "1.4.0",
-    "fabric-client": "1.4.0",
+    "fabric-ca-client": "^1.3.0",
+    "fabric-client": "^1.3.0",
     "khala-nodeutils": "^0.2.7"
   },
   "cryptoKeyStore": "../keyStoreCache"

--- a/nodejs/peer.js
+++ b/nodejs/peer.js
@@ -1,4 +1,5 @@
 const Peer = require('fabric-client/lib/Peer');
+const fs = require('fs');
 const {fsExtra} = require('khala-nodeutils/helper');
 const {RequestPromise} = require('khala-nodeutils/request');
 exports.new = ({peerPort, peerHostName, cert, pem, host}) => {
@@ -23,6 +24,18 @@ exports.new = ({peerPort, peerHostName, cert, pem, host}) => {
 		return new Peer(peerUrl);
 	}
 };
+
+exports.buildPeer = (client, peerUrl, peerHostName, peerTlsCaPemPath) => {
+    const newData = fs.readFileSync(peerTlsCaPemPath);
+    return client.newPeer(
+        peerUrl,
+        {
+            pem: Buffer.from(newData).toString(),
+            'ssl-target-name-override': peerHostName
+        }
+    );
+}
+
 exports.formatPeerName = (peerName, domain) => `${peerName}.${domain}`;
 
 exports.container =


### PR DESCRIPTION
1. enhance common API by enabling service discovery
2. downgrade the fabric-client & fabric-ca-client from 1.4.0 to 1.3.0 (for the service discovery failure)